### PR TITLE
Add tox config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,8 @@ At the time of writing, all 27 tests pass on:
 * Raspbian Jessie
 * Mac OS/X 10.11
 
+* Tests: to run the tests, run tox
+
 API
 ---
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27, py33, py34, py35
+
+[testenv]
+commands = py.test {posargs:tests/}
+deps =
+    pytest


### PR DESCRIPTION
Add tox.ini for running tests against py27, py33, py34 & py35 (skipping those not available).