### PR TITLE
Fix Travis-CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.5"
 # install dependencies
 install:
-    - pip install pytest
-    - pip install tox
+    - pip install tox tox-travis
 # run tests
 script: tox


### PR DESCRIPTION
This add [tox-travis](https://pypi.python.org/pypi/tox-travis) which will run the correct py version for each travis env.

See https://travis-ci.org/tomviner/networkzero/builds/122322820 for successful build of this branch. All Python versions pass.

I couldn't add MacOS, as [unfortunately travis-ci say](https://docs.travis-ci.com/user/languages/python):

> Python builds are not available on the OSX environment.

The instructions for you @tjguk to setup travis-ci for this repo, before merging this PR:

1. Sign-in with github auth here: https://travis-ci.org/
1. Allow it the permissions it requests, at least for your user namespace (you don't need to give access to github orgs you're a member of)
1. It should sync up the list of your repos
1. Toggle networkzero to **on**
1. Merge this PR, and see if it builds.
    * If it doesn't it just needs me to push another commit to this branch for it to get the first webhook call. But in future PRs should build upon creation and report back in the PR (and with an email to you, which you can turn off in your travis-ci settings).

Next, I will move on to look at [Appveyor](https://www.appveyor.com/), to run tests on Windows next.