### PR TITLE
Add MacOSX to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,33 @@
 # Based on https://github.com/pyca/cryptography/blob/master/.travis.yml
+# which is subject to the following BSD license:
+
+# Copyright (c) Individual contributors.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+
+#     3. Neither the name of PyCA Cryptography nor the names of its contributors
+#        may be used to endorse or promote products derived from this software
+#        without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,36 @@
+# Based on https://github.com/pyca/cryptography/blob/master/.travis.yml
+
+sudo: false
+
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-# install dependencies
-install:
-    - pip install tox tox-travis
-# run test command
-script: tox
+
+matrix:
+    include:
+        - python: 2.7 # these are just to make travis's UI a bit prettier
+          env: TOXENV=py27
+        - python: 3.3
+          env: TOXENV=py33
+        - python: 3.4
+          env: TOXENV=py34
+        - python: 3.5
+          env: TOXENV=py35
+        - os: osx
+          language: generic
+          python: 2.7
+          env: TOXENV=py27
+        - os: osx
+          language: generic
+          python: 3.3
+          env: TOXENV=py33
+        - os: osx
+          language: generic
+          python: 3.4
+          env: TOXENV=py34
+        - os: osx
+          language: generic
+          python: 3.5
+          env: TOXENV=py35
+
+install: ./.travis/install.sh
+
+script: source ~/.venv/bin/activate && tox

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,6 +1,35 @@
 #!/bin/bash
 
 # Based on https://github.com/pyca/cryptography/blob/master/.travis/install.sh
+# which is subject to the following BSD license:
+
+# Copyright (c) Individual contributors.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+
+#     3. Neither the name of PyCA Cryptography nor the names of its contributors
+#        may be used to endorse or promote products derived from this software
+#        without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set -e
 set -x

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Based on https://github.com/pyca/cryptography/blob/master/.travis/install.sh
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew update || brew update
+
+    brew outdated zeromq || brew upgrade zeromq
+
+    # install pyenv
+    git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+    PYENV_ROOT="$HOME/.pyenv"
+    PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init -)"
+
+    case "${TOXENV}" in
+        py27)
+            curl -O https://bootstrap.pypa.io/get-pip.py
+            python get-pip.py --user
+            ;;
+        py33)
+            pyenv install 3.3.6
+            pyenv global 3.3.6
+            ;;
+        py34)
+            pyenv install 3.4.4
+            pyenv global 3.4.4
+            ;;
+        py35)
+            pyenv install 3.5.1
+            pyenv global 3.5.1
+            ;;
+    esac
+    pyenv rehash
+    python -m pip install --user virtualenv
+else
+    pip install virtualenv
+fi
+
+python -m virtualenv ~/.venv
+source ~/.venv/bin/activate
+pip install tox


### PR DESCRIPTION
Following the method used in the [cryptography](https://github.com/pyca/cryptography) library, I've got MacOSX working on Travis-CI.

So all 4 Python versions now run on linux & osx. Interestingly, before I pulled in your latest changes @tjguk [I got a single failing test](https://travis-ci.org/tomviner/networkzero/builds/122461828), just for osx/Py3.5.

I've attributed the source, and put the license inline. Hope this is ok. It's a permissive license that basically says you must supply the license.

cryptography actually [has two licenses](https://github.com/pyca/cryptography/blob/master/LICENSE), so I've picked the shorter, slightly more permissive one.